### PR TITLE
Make redbean even smaller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,10 @@
 FROM alpine:latest AS build
 
-ARG DOWNLOAD_FILENAME=redbean-original-1.4.com
+ARG DOWNLOAD_FILENAME=redbean-original-tinylinux-1.4.com
 
 RUN apk add --update zip bash
 RUN wget https://justine.lol/redbean/${DOWNLOAD_FILENAME} -O redbean.com
 RUN chmod +x redbean.com
-
-# This will normalize the binary to ELF
-RUN zip -d redbean.com .ape
-RUN ls -la redbean.com
-RUN zip -sf redbean.com
-RUN bash /redbean.com -h
-
 
 FROM scratch
 


### PR DESCRIPTION
Using the [tinylinux version of Redbean](https://github.com/jart/cosmopolitan/issues/202#issuecomment-873650544) makes the Docker image even smaller (only 150KB).